### PR TITLE
fix: add SPA behavior

### DIFF
--- a/src/components/RouterLink/RouterLink.js
+++ b/src/components/RouterLink/RouterLink.js
@@ -1,0 +1,12 @@
+import Link from '@material-ui/core/Link';
+import { Link as RRouterLink } from 'react-router-dom';
+
+function RouterLink({ children, to, ...props }) {
+  return (
+    <Link component={RRouterLink} to={to} variant="body2" {...props}>
+      {children}
+    </Link>
+  );
+}
+
+export default RouterLink;

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Link as RouterLink, withRouter } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import image from '../assets/Monster404.svg';
 import Grid from '@material-ui/core/Grid';
-import Link from '@material-ui/core/Link';
 import { useTranslation } from 'react-i18next';
+import RouterLink from '../components/RouterLink/RouterLink';
 
 const useStyles = makeStyles((theme) => ({
   img: {
@@ -31,9 +31,9 @@ function NotFound() {
 
       <Grid alignItems="center" direction="column" justifyContent="center" container>
         <Grid item xs>
-          <Link component={RouterLink} to="/" variant="body2">
+          <RouterLink to="/">
             {t('medicalReport')}
-          </Link>
+          </RouterLink>
         </Grid>
       </Grid>
     </div>

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withRouter } from 'react-router-dom';
+import { Link as RouterLink, withRouter } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import image from '../assets/Monster404.svg';
 import Grid from '@material-ui/core/Grid';
@@ -31,7 +31,7 @@ function NotFound() {
 
       <Grid alignItems="center" direction="column" justifyContent="center" container>
         <Grid item xs>
-          <Link href="/" variant="body2">
+          <Link component={RouterLink} to="/" variant="body2">
             {t('medicalReport')}
           </Link>
         </Grid>

--- a/src/pages/hospitals/Login.js
+++ b/src/pages/hospitals/Login.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory, withRouter } from 'react-router-dom';
+import { Link as RouterLink, useHistory, withRouter } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import TextField from '@material-ui/core/TextField';
@@ -126,17 +126,17 @@ function Login() {
             )}
             <Grid alignItems="center" container>
               <Grid item xs={12}>
-                <Link href="/hospitals/reset" variant="body2">
+                <Link component={RouterLink} to="/hospitals/reset" variant="body2">
                   {t('forgotPassword')}?
                 </Link>
               </Grid>
               <Grid item xs={12}>
-                <Link href="/hospitals/register" variant="body2">
+                <Link component={RouterLink} to="/hospitals/register" variant="body2">
                   {t('addHospital')}
                 </Link>
               </Grid>
               <Grid item xs={12}>
-                <Link href="/patients/login" variant="body2">
+                <Link component={RouterLink} to="/patients/login" variant="body2">
                   {t('patientFamilyLogin')}
                 </Link>
               </Grid>

--- a/src/pages/hospitals/Login.js
+++ b/src/pages/hospitals/Login.js
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { Link as RouterLink, useHistory, withRouter } from 'react-router-dom';
+import { useHistory, withRouter } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import TextField from '@material-ui/core/TextField';
-import Link from '@material-ui/core/Link';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
@@ -13,6 +12,7 @@ import api from '../../services/Api';
 import { toast } from 'react-toastify';
 import AppBarMediRepo from '../components/AppBarMediRepo';
 import { useTranslation } from 'react-i18next';
+import RouterLink from '../../components/RouterLink/RouterLink';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -126,19 +126,19 @@ function Login() {
             )}
             <Grid alignItems="center" container>
               <Grid item xs={12}>
-                <Link component={RouterLink} to="/hospitals/reset" variant="body2">
+                <RouterLink to="/hospitals/reset">
                   {t('forgotPassword')}?
-                </Link>
+                </RouterLink>
               </Grid>
               <Grid item xs={12}>
-                <Link component={RouterLink} to="/hospitals/register" variant="body2">
+                <RouterLink to="/hospitals/register">
                   {t('addHospital')}
-                </Link>
+                </RouterLink>
               </Grid>
               <Grid item xs={12}>
-                <Link component={RouterLink} to="/patients/login" variant="body2">
+                <RouterLink to="/patients/login">
                   {t('patientFamilyLogin')}
-                </Link>
+                </RouterLink>
               </Grid>
             </Grid>
           </form>

--- a/src/pages/hospitals/Register.js
+++ b/src/pages/hospitals/Register.js
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { Link as RouterLink, useHistory, withRouter } from 'react-router-dom';
+import { useHistory, withRouter } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import TextField from '@material-ui/core/TextField';
 import Grid from '@material-ui/core/Grid';
-import Link from '@material-ui/core/Link';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
@@ -13,6 +12,7 @@ import api from '../../services/Api';
 import AppBarMediRepo from '../components/AppBarMediRepo';
 import { toast } from 'react-toastify';
 import { useTranslation } from 'react-i18next';
+import RouterLink from '../../components/RouterLink/RouterLink';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -170,9 +170,7 @@ function RegisterHospital() {
             )}
             <Grid alignItems="center" container>
               <Grid item>
-                <Link component={RouterLink} to="/hospitals/login" variant="body2">
-                  {t('alreadyHaveLogin')}
-                </Link>
+                <RouterLink to="/hospitals/login">{t('alreadyHaveLogin')}</RouterLink>
               </Grid>
             </Grid>
           </form>

--- a/src/pages/hospitals/Register.js
+++ b/src/pages/hospitals/Register.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useHistory, withRouter } from 'react-router-dom';
+import { Link as RouterLink, useHistory, withRouter } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import TextField from '@material-ui/core/TextField';
@@ -170,7 +170,7 @@ function RegisterHospital() {
             )}
             <Grid alignItems="center" container>
               <Grid item>
-                <Link href="/hospitals/login" variant="body2">
+                <Link component={RouterLink} to="/hospitals/login" variant="body2">
                   {t('alreadyHaveLogin')}
                 </Link>
               </Grid>

--- a/src/pages/hospitals/ResetToken.js
+++ b/src/pages/hospitals/ResetToken.js
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { Link as RouterLink, withRouter } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import TextField from '@material-ui/core/TextField';
-import Link from '@material-ui/core/Link';
 import VpnKeyIcon from '@material-ui/icons/VpnKey';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
@@ -13,6 +12,7 @@ import api from '../../services/Api';
 import { toast } from 'react-toastify';
 import AppBarMediRepo from '../components/AppBarMediRepo';
 import { useTranslation } from 'react-i18next';
+import RouterLink from '../../components/RouterLink/RouterLink';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -108,9 +108,7 @@ function ResetToken() {
             )}
             <Grid alignItems="center" container>
               <Grid item>
-                <Link component={RouterLink} to="/hospitals/login" variant="body2">
-                  {t('hospitalLogin')}
-                </Link>
+                <RouterLink to="/hospitals/login">{t('hospitalLogin')}</RouterLink>
               </Grid>
             </Grid>
           </form>

--- a/src/pages/hospitals/ResetToken.js
+++ b/src/pages/hospitals/ResetToken.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { withRouter } from 'react-router-dom';
+import { Link as RouterLink, withRouter } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import TextField from '@material-ui/core/TextField';
@@ -108,7 +108,7 @@ function ResetToken() {
             )}
             <Grid alignItems="center" container>
               <Grid item>
-                <Link href="/hospitals/login" variant="body2">
+                <Link component={RouterLink} to="/hospitals/login" variant="body2">
                   {t('hospitalLogin')}
                 </Link>
               </Grid>

--- a/src/pages/patients/Login.js
+++ b/src/pages/patients/Login.js
@@ -1,12 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { Link as RouterLink, useHistory, withRouter } from 'react-router-dom';
+import { useHistory, withRouter } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import TextField from '@material-ui/core/TextField';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import Select from '@material-ui/core/Select';
-import Link from '@material-ui/core/Link';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
@@ -17,6 +16,7 @@ import api from '../../services/Api';
 import { toast } from 'react-toastify';
 import AppBarMediRepo from '../components/AppBarMediRepo';
 import { useTranslation } from 'react-i18next';
+import RouterLink from '../../components/RouterLink/RouterLink';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -184,14 +184,12 @@ function SignIn() {
             )}{' '}
             <Grid alignItems="center" container>
               <Grid item xs>
-                <Link component={RouterLink} to="#" onClick={notify} variant="body2">
+                <RouterLink to="#" onClick={notify}>
                   {t('forgotPassword')}?
-                </Link>
+                </RouterLink>
               </Grid>
               <Grid item>
-                <Link component={RouterLink} to="/hospitals/login" variant="body2">
-                  {t('hospitalLogin')}
-                </Link>
+                <RouterLink to="/hospitals/login">{t('hospitalLogin')}</RouterLink>
               </Grid>
             </Grid>
           </form>

--- a/src/pages/patients/Login.js
+++ b/src/pages/patients/Login.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useHistory, withRouter } from 'react-router-dom';
+import { Link as RouterLink, useHistory, withRouter } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import TextField from '@material-ui/core/TextField';
@@ -184,12 +184,12 @@ function SignIn() {
             )}{' '}
             <Grid alignItems="center" container>
               <Grid item xs>
-                <Link href="#" onClick={notify} variant="body2">
+                <Link component={RouterLink} to="#" onClick={notify} variant="body2">
                   {t('forgotPassword')}?
                 </Link>
               </Grid>
               <Grid item>
-                <Link href="/hospitals/login" variant="body2">
+                <Link component={RouterLink} to="/hospitals/login" variant="body2">
                   {t('hospitalLogin')}
                 </Link>
               </Grid>


### PR DESCRIPTION
## The problem
React is a web ui library used to build SPA. One of the benefits of SPA is the reactivity while navigate throught the app: when you go from `/page1/` to `/page/2`, the window will not be refreshed.
Nothing wrong if the page refresh on old PHP-ish solutions. The problem is with client-side JS frameworks routing...

## Why?
Client-side JS frameworks needs download all JS necesary to work normally, this will be hundred of kB (or MB!!). Again, nothing wrong with this approach (to much modern biggest apps work in this way nowadays), but when the window is refreshed in every navigation, the user is downloading all JS every single time if client-side routing is not handled proprely.

## Solution
Use the `<Link />` component provided by `react-router-dom` with the `<Link />` component provided by Material UI.

### Related
https://mui.com/material-ui/guides/routing/#link