### PR TITLE
Add required asterisk(*) mark in hospital input in login form

### DIFF
--- a/src/pages/patients/Login.js
+++ b/src/pages/patients/Login.js
@@ -153,7 +153,7 @@ function SignIn() {
               autoComplete={t('birthday')}
               onChange={(e) => setDtnasc(e.target.value)}
             />
-            <FormControl className={classes.formControl} variant="outlined">
+            <FormControl required className={classes.formControl} variant="outlined">
               <InputLabel htmlFor="nascimento" id="simple-select-outlined-label">
                 Hospital
               </InputLabel>
@@ -166,7 +166,7 @@ function SignIn() {
                   name: 'hospital',
                   id: 'hospital_id',
                 }}
-                input={<OutlinedInput shrink="true" labelWidth={62} name="hospital" id="simple-select-outline" />}
+                input={<OutlinedInput shrink="true" labelWidth={70} name="hospital" id="simple-select-outline" />}
                 onChange={(e) => setHospital(e.target.value)}
               >
                 <option aria-label="None" value="" />


### PR DESCRIPTION
### Issue
- even if hospital input is required in login form there was no asterisk mark in the label

## Before 

<img width="493" alt="image" src="https://user-images.githubusercontent.com/75303263/197358616-c2e77491-590a-4b68-91f1-32a74f124b34.png">

<img width="484" alt="image" src="https://user-images.githubusercontent.com/75303263/197358621-da031e3b-5688-4fee-a143-3f6f42f1eef7.png">


## After 

<img width="525" alt="image" src="https://user-images.githubusercontent.com/75303263/197358593-f09c769a-ecc9-43cb-8abe-accb4c0ec8f1.png">

<img width="493" alt="image" src="https://user-images.githubusercontent.com/75303263/197358607-cb826980-05c7-4e97-b60e-a12c49993370.png">
